### PR TITLE
stubbed Date => now in customer_extensions spec

### DIFF
--- a/spec/extensions/customer_extension_spec.rb
+++ b/spec/extensions/customer_extension_spec.rb
@@ -6,6 +6,7 @@ describe SalesEngine::Customer, customer: true do
     describe "#days_since_activity" do
       it "returns a count of the days since the customer's last transaction" do
         DateTime.stub(:now => DateTime.parse("March 29, 2012"))
+        Date.stub(:today => Date.parse("March 29, 2012"))
         days_since = SalesEngine::Customer.find_by_id(1).days_since_activity
 
         days_since.should == 4


### PR DESCRIPTION
some of us wrote the days_since_activity to use Date rather than DateTime
