### PR TITLE
use a random transaction instead of a double

### DIFF
--- a/spec/extensions/customer_extension_spec.rb
+++ b/spec/extensions/customer_extension_spec.rb
@@ -22,7 +22,7 @@ describe SalesEngine::Customer, customer: true do
       context "when there are pending invoices" do
         let(:first_invoice) { SalesEngine::Customer.find_by_id(2).invoices.first }
         it "returns an array of the pending invoices" do
-          bad_transaction = double("transaction")
+          bad_transaction = SalesEngine::Transaction.random
           bad_transaction.stub(:result => "failed")
           first_invoice.stub(:transactions => [bad_transaction])
 


### PR DESCRIPTION
Some people used helper methods on SalesEngine::Transaction to test "successful", so using a stub gives errors when it doesn't respond to this method. Using a random transaction and forcing into the invoice in question seems to fix this problem
