### PR TITLE
Updated invoice_spec.rb

### DIFF
--- a/spec/invoice_spec.rb
+++ b/spec/invoice_spec.rb
@@ -86,7 +86,7 @@ describe SalesEngine::Invoice do
           invoice.items.map(&:name).should include(name)
         end
 
-        #invoice.merchant.id.should == merchant.id
+        invoice.merchant_id.should == merchant.id
         invoice.customer.id.should == customer.id
       end
     end


### PR DESCRIPTION
Changing this line will align the spec with the base requirements to be able to call .merchant_id on an invoice.

The ability to call .merchant on an invoice was not in the base requirements.
