### PR TITLE
Update item_spec.rb

### DIFF
--- a/spec/item_spec.rb
+++ b/spec/item_spec.rb
@@ -18,7 +18,7 @@ describe "SalesEngine items" do
 
     describe ".find_by_unit_price" do
       it "can find one record" do
-        item = engine.item_repository.find_by_unit_price BigDecimal.new("935.19")
+        item = engine.item_repository.find_by_unit_price BigDecimal.new("93519")
         item.name.should == "Item Alias Nihil"
       end
     end


### PR DESCRIPTION
in line 21, the bigdecimal value 935.19 wont ever appear in a query because in the csv it is listed as 93519.  if x = BigDecimal.new("935.19"), and y = BigDecimal.new("93519") then x ≠ y because x = 0.93519E3 and y = 0.93519E5
